### PR TITLE
More solid Implementation

### DIFF
--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -242,22 +242,23 @@ export default class Float16Array extends Uint16Array {
     }
 
     // functional methods
-    // @ts-ignore
     map(callback, ...opts) {
         assertFloat16Array(this);
 
         const thisArg = opts[0];
 
-        const array = [];
-        for(let i = 0, l = this.length; i < l; ++i) {
+        const length = this.length;
+        const proxy = new Float16Array(length);
+        const float16bits = _(proxy).target;
+
+        for(let i = 0; i < length; ++i) {
             const val = convertToNumber(this[i]);
-            array.push(callback.call(thisArg, val, i, _(this).proxy));
+            float16bits[i] = roundToFloat16Bits(callback.call(thisArg, val, i, _(this).proxy));
         }
 
-        return new Float16Array(array);
+        return proxy;
     }
 
-    // @ts-ignore
     filter(callback, ...opts) {
         assertFloat16Array(this);
 
@@ -277,42 +278,49 @@ export default class Float16Array extends Uint16Array {
     reduce(callback, ...opts) {
         assertFloat16Array(this);
 
-        let val, start;
+        const length = this.length;
+        if (length === 0 && opts.length === 0) {
+            throw TypeError("Reduce of empty array with no initial value");
+        }
 
+        let accumulator, start;
         if (opts.length === 0) {
-            val = convertToNumber(this[0]);
+            accumulator = convertToNumber(this[0]);
             start = 1;
         } else {
-            val = opts[0];
+            accumulator = opts[0];
             start = 0;
         }
 
-        for(let i = start, l = this.length; i < l; ++i) {
-            val = callback(val, convertToNumber(this[i]), i, _(this).proxy);
+        for(let i = start; i < length; ++i) {
+            accumulator = callback(accumulator, convertToNumber(this[i]), i, _(this).proxy);
         }
 
-        return val;
+        return accumulator;
     }
 
     reduceRight(callback, ...opts) {
         assertFloat16Array(this);
 
-        let val, start;
-
         const length = this.length;
+        if (length === 0 && opts.length === 0) {
+            throw TypeError("Reduce of empty array with no initial value");
+        }
+
+        let accumulator, start;
         if (opts.length === 0) {
-            val = convertToNumber(this[length - 1]);
-            start = length - 1;
+            accumulator = convertToNumber(this[length - 1]);
+            start = length - 2;
         } else {
-            val = opts[0];
-            start = length;
+            accumulator = opts[0];
+            start = length - 1;
         }
 
-        for(let i = start; i--;) {
-            val = callback(val, convertToNumber(this[i]), i, _(this).proxy);
+        for(let i = start; i >= 0; --i) {
+            accumulator = callback(accumulator, convertToNumber(this[i]), i, _(this).proxy);
         }
 
-        return val;
+        return accumulator;
     }
 
     forEach(callback, ...opts) {

--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -168,7 +168,6 @@ export default class Float16Array extends Uint16Array {
         const float16bits = _(proxy).target;
 
         for(let i = 0; i < length; ++i) {
-            // super (Uint16Array)
             float16bits[i] = roundToFloat16Bits(items[i]);
         }
 
@@ -176,27 +175,56 @@ export default class Float16Array extends Uint16Array {
     }
 
     // iterate methods
-    * [Symbol.iterator]() {
-        for(const val of super[Symbol.iterator]()) {
-            yield convertToNumber(val);
-        }
+    [Symbol.iterator]() {
+        const arrayIterator = super[Symbol.iterator]();
+
+        const iterator = (function* () {
+            for(const val of arrayIterator) {
+                yield convertToNumber(val);
+            }
+        })();
+
+        // ArrayIterator doesn't have return and throw method
+        iterator.return = undefined;
+        iterator.throw = undefined;
+
+        return iterator;
     }
 
     keys() {
         return super.keys();
     }
 
-    * values() {
-        for(const val of super.values()) {
-            yield convertToNumber(val);
-        }
+    values() {
+        const arrayIterator = super.values();
+
+        const iterator = (function* () {
+            for(const val of arrayIterator) {
+                yield convertToNumber(val);
+            }
+        })();
+
+        // ArrayIterator doesn't have return and throw method
+        iterator.return = undefined;
+        iterator.throw = undefined;
+
+        return iterator;
     }
 
-    /** @type {() => IterableIterator<[number, number]>} */
-    * entries() {
-        for(const [i, val] of super.entries()) {
-            yield [i, convertToNumber(val)];
-        }
+    entries() {
+        const arrayIterator = super.entries();
+
+        const iterator = (function* () {
+            for(const [i, val] of arrayIterator) {
+                yield [i, convertToNumber(val)];
+            }
+        })();
+
+        // ArrayIterator doesn't have return and throw method
+        iterator.return = undefined;
+        iterator.throw = undefined;
+
+        return iterator;
     }
 
     at(index) {

--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -161,8 +161,18 @@ export default class Float16Array extends Uint16Array {
         }, thisArg).buffer);
     }
 
-    static of(...args) {
-        return new Float16Array(args);
+    static of(...items) {
+        const length = items.length;
+
+        const proxy = new Float16Array(length);
+        const float16bits = _(proxy).target;
+
+        for(let i = 0; i < length; ++i) {
+            // super (Uint16Array)
+            float16bits[i] = roundToFloat16Bits(items[i]);
+        }
+
+        return proxy;
     }
 
     // iterate methods

--- a/test/Float16Array.js
+++ b/test/Float16Array.js
@@ -305,7 +305,22 @@ describe("Float16Array", () => {
         it("get keys", () => {
             const float16 = new Float16Array([1, 2, 3]);
             const array = [...float16.keys()];
+
             assert.deepStrictEqual( array, [0, 1, 2] );
+        });
+
+        it("suspend to iterate keys", () => {
+            const float16 = new Float16Array([1, 2, 3]);
+            const iterator = float16.keys();
+
+            for (const key of iterator) {
+                if (key === 1) {
+                    break;
+                }
+            }
+
+            assert.deepStrictEqual( iterator.next(), { value: 2, done: false } );
+            assert.deepStrictEqual( iterator.next(), { value: undefined, done: true } );
         });
 
     });
@@ -327,6 +342,20 @@ describe("Float16Array", () => {
             assert.deepStrictEqual( array, [1, 2, 3] );
         });
 
+        it("suspend to iterate values", () => {
+            const float16 = new Float16Array([1, 2, 3]);
+            const iterator = float16.values();
+
+            for (const value of iterator) {
+                if (value === 2) {
+                    break;
+                }
+            }
+
+            assert.deepStrictEqual( iterator.next(), { value: 3, done: false } );
+            assert.deepStrictEqual( iterator.next(), { value: undefined, done: true } );
+        });
+
     });
 
     describe("#entries()", () => {
@@ -339,11 +368,26 @@ describe("Float16Array", () => {
             assert( Float16Array.prototype.entries.length === 0 );
         });
 
-        it("get values", () => {
+        it("get entries", () => {
             const float16 = new Float16Array([1, 2, 3]);
             const array = [...float16.entries()];
 
             assert.deepStrictEqual( array, [[0, 1], [1, 2], [2, 3]] );
+        });
+
+        it("suspend to iterate entries", () => {
+            const float16 = new Float16Array([1, 2, 3]);
+            const iterator = float16.entries();
+
+            // eslint-disable-next-line no-unused-vars
+            for (const [_, value] of iterator) {
+                if (value === 2) {
+                    break;
+                }
+            }
+
+            assert.deepStrictEqual( iterator.next(), { value: [2, 3], done: false } );
+            assert.deepStrictEqual( iterator.next(), { value: undefined, done: true } );
         });
 
     });

--- a/test/Float16Array.js
+++ b/test/Float16Array.js
@@ -520,6 +520,11 @@ describe("Float16Array", () => {
             assert( val === "123" );
         });
 
+        it("throw TypeError on empty array with no initial value", () => {
+            const float16 = new Float16Array();
+            assert.throws(() => float16.reduce(() => {}), TypeError);
+        });
+
     });
 
     describe("#reduceRight()", () => {
@@ -560,6 +565,11 @@ describe("Float16Array", () => {
             const float16 = new Float16Array([1, 2, 3]);
             const val = float16.reduceRight((prev, current) => prev + current, "");
             assert( val === "321" );
+        });
+
+        it("throw TypeError on empty array with no initial value", () => {
+            const float16 = new Float16Array();
+            assert.throws(() => float16.reduce(() => {}), TypeError);
         });
 
     });


### PR DESCRIPTION
* `Float16Array.of` is not constructor wrapper
* `Float16Array#{values, entries, @@iterator}` returns iteretor that doesn't have `"return"` and `"throw"` methods
* `Float16Array#{map, includes}` optimization
* `Float16Array#reduce{, Right}` throws `TypeError` on empty array with no initial value