### PR TITLE
More solid Implementation part3

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This API is similar to `TypedArray` such as `Float32Array`.
 
 ```js
 const array = new Float16Array([1.0, 1.1, 1.2]);
-for(const val of array) {
+for (const val of array) {
     console.log(val); // => 1, 1.099609375, 1.19921875
 }
 

--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -1,6 +1,6 @@
 import memoize from "lodash-es/memoize.js";
 import { wrapInArrayIterator } from "./arrayIterator.mjs";
-import { isArrayBuffer, isCanonicalIntegerIndexString , isIterable, isObject, isSharedArrayBuffer, isTypedArray } from "./is.mjs";
+import { isArrayBuffer, isCanonicalIntegerIndexString ,isIterable, isObject, isSharedArrayBuffer, isTypedArray } from "./is.mjs";
 import { convertToNumber, roundToFloat16Bits } from "./lib.mjs";
 import { createPrivateStorage } from "./private.mjs";
 import { LengthOfArrayLike, SpeciesConstructor, ToIntegerOrInfinity, defaultCompareFunction } from "./spec.mjs";
@@ -49,7 +49,7 @@ function copyToArray(float16bits) {
     const length = float16bits.length;
 
     const array = [];
-    for(let i = 0; i < length; ++i) {
+    for (let i = 0; i < length; ++i) {
         array.push(convertToNumber(float16bits[i]));
     }
 
@@ -131,7 +131,7 @@ export default class Float16Array extends Uint16Array {
                 const length = list.length;
                 super(length);
 
-                for(let i = 0; i < length; ++i) {
+                for (let i = 0; i < length; ++i) {
                     // super (Uint16Array)
                     this[i] = roundToFloat16Bits(list[i]);
                 }
@@ -141,7 +141,7 @@ export default class Float16Array extends Uint16Array {
                 const length = LengthOfArrayLike(input);
                 super(length);
 
-                for(let i = 0; i < length; ++i) {
+                for (let i = 0; i < length; ++i) {
                     // super (Uint16Array)
                     this[i] = roundToFloat16Bits(input[i]);
                 }
@@ -149,7 +149,7 @@ export default class Float16Array extends Uint16Array {
 
         // primitive, ArrayBuffer
         } else {
-            switch(arguments.length) {
+            switch (arguments.length) {
                 case 0:
                     super();
                     break;
@@ -207,7 +207,7 @@ export default class Float16Array extends Uint16Array {
         const proxy = new Float16Array(length);
         const float16bits = _(proxy).target;
 
-        for(let i = 0; i < length; ++i) {
+        for (let i = 0; i < length; ++i) {
             float16bits[i] = roundToFloat16Bits(items[i]);
         }
 
@@ -232,7 +232,7 @@ export default class Float16Array extends Uint16Array {
 
         const arrayIterator = super.values();
         return wrapInArrayIterator((function* () {
-            for(const val of arrayIterator) {
+            for (const val of arrayIterator) {
                 yield convertToNumber(val);
             }
         })());
@@ -247,7 +247,7 @@ export default class Float16Array extends Uint16Array {
 
         const arrayIterator = super.entries();
         return wrapInArrayIterator((function* () {
-            for(const [i, val] of arrayIterator) {
+            for (const [i, val] of arrayIterator) {
                 yield [i, convertToNumber(val)];
             }
         })());
@@ -287,7 +287,7 @@ export default class Float16Array extends Uint16Array {
             const proxy = new Float16Array(length);
             const float16bits = _(proxy).target;
 
-            for(let i = 0; i < length; ++i) {
+            for (let i = 0; i < length; ++i) {
                 const val = convertToNumber(this[i]);
                 float16bits[i] = roundToFloat16Bits(callback.call(thisArg, val, i, _(this).proxy));
             }
@@ -297,7 +297,7 @@ export default class Float16Array extends Uint16Array {
 
         const array = new Constructor(length);
 
-        for(let i = 0; i < length; ++i) {
+        for (let i = 0; i < length; ++i) {
             const val = convertToNumber(this[i]);
             array[i] = callback.call(thisArg, val, i, _(this).proxy);
         }
@@ -314,7 +314,7 @@ export default class Float16Array extends Uint16Array {
         const thisArg = opts[0];
 
         const kept = [];
-        for(let i = 0, l = this.length; i < l; ++i) {
+        for (let i = 0, l = this.length; i < l; ++i) {
             const val = convertToNumber(this[i]);
             if (callback.call(thisArg, val, i, _(this).proxy)) {
                 kept.push(val);
@@ -347,7 +347,7 @@ export default class Float16Array extends Uint16Array {
             start = 0;
         }
 
-        for(let i = start; i < length; ++i) {
+        for (let i = start; i < length; ++i) {
             accumulator = callback(accumulator, convertToNumber(this[i]), i, _(this).proxy);
         }
 
@@ -374,7 +374,7 @@ export default class Float16Array extends Uint16Array {
             start = length - 1;
         }
 
-        for(let i = start; i >= 0; --i) {
+        for (let i = start; i >= 0; --i) {
             accumulator = callback(accumulator, convertToNumber(this[i]), i, _(this).proxy);
         }
 
@@ -389,7 +389,7 @@ export default class Float16Array extends Uint16Array {
 
         const thisArg = opts[0];
 
-        for(let i = 0, l = this.length; i < l; ++i) {
+        for (let i = 0, l = this.length; i < l; ++i) {
             callback.call(thisArg, convertToNumber(this[i]), i, _(this).proxy);
         }
     }
@@ -402,7 +402,7 @@ export default class Float16Array extends Uint16Array {
 
         const thisArg = opts[0];
 
-        for(let i = 0, l = this.length; i < l; ++i) {
+        for (let i = 0, l = this.length; i < l; ++i) {
             const value = convertToNumber(this[i]);
             if (callback.call(thisArg, value, i, _(this).proxy)) {
                 return value;
@@ -418,7 +418,7 @@ export default class Float16Array extends Uint16Array {
 
         const thisArg = opts[0];
 
-        for(let i = 0, l = this.length; i < l; ++i) {
+        for (let i = 0, l = this.length; i < l; ++i) {
             const value = convertToNumber(this[i]);
             if (callback.call(thisArg, value, i, _(this).proxy)) {
                 return i;
@@ -436,7 +436,7 @@ export default class Float16Array extends Uint16Array {
 
         const thisArg = opts[0];
 
-        for(let i = this.length - 1; i >= 0; --i) {
+        for (let i = this.length - 1; i >= 0; --i) {
             const value = convertToNumber(this[i]);
             if (callback.call(thisArg, value, i, _(this).proxy)) {
                 return value;
@@ -452,7 +452,7 @@ export default class Float16Array extends Uint16Array {
 
         const thisArg = opts[0];
 
-        for(let i = this.length - 1; i >= 0; --i) {
+        for (let i = this.length - 1; i >= 0; --i) {
             const value = convertToNumber(this[i]);
             if (callback.call(thisArg, value, i, _(this).proxy)) {
                 return i;
@@ -470,7 +470,7 @@ export default class Float16Array extends Uint16Array {
 
         const thisArg = opts[0];
 
-        for(let i = 0, l = this.length; i < l; ++i) {
+        for (let i = 0, l = this.length; i < l; ++i) {
             if (!callback.call(thisArg, convertToNumber(this[i]), i, _(this).proxy)) {
                 return false;
             }
@@ -487,7 +487,7 @@ export default class Float16Array extends Uint16Array {
 
         const thisArg = opts[0];
 
-        for(let i = 0, l = this.length; i < l; ++i) {
+        for (let i = 0, l = this.length; i < l; ++i) {
             if (callback.call(thisArg, convertToNumber(this[i]), i, _(this).proxy)) {
                 return true;
             }
@@ -517,7 +517,7 @@ export default class Float16Array extends Uint16Array {
         } else {
             const length = LengthOfArrayLike(input);
             float16bits = new Uint16Array(length);
-            for(let i = 0; i < length; ++i) {
+            for (let i = 0; i < length; ++i) {
                 float16bits[i] = roundToFloat16Bits(input[i]);
             }
         }
@@ -668,7 +668,7 @@ export default class Float16Array extends Uint16Array {
             }
         }
 
-        for(let i = from, l = length; i < l; ++i) {
+        for (let i = from, l = length; i < l; ++i) {
             if (Object.prototype.hasOwnProperty.call(this, i) && convertToNumber(this[i]) === element) {
                 return i;
             }
@@ -696,7 +696,7 @@ export default class Float16Array extends Uint16Array {
             from += length;
         }
 
-        for(let i = from; i >= 0; --i) {
+        for (let i = from; i >= 0; --i) {
             if (Object.prototype.hasOwnProperty.call(this, i) && convertToNumber(this[i]) === element) {
                 return i;
             }
@@ -726,7 +726,7 @@ export default class Float16Array extends Uint16Array {
         }
 
         const isNaN = Number.isNaN(element);
-        for(let i = from, l = length; i < l; ++i) {
+        for (let i = from, l = length; i < l; ++i) {
             const value = convertToNumber(this[i]);
 
             if (isNaN && Number.isNaN(value)) {
@@ -785,7 +785,7 @@ Object.defineProperty(Float16ArrayPrototype, Symbol.iterator, {
 });
 
 const defaultFloat16ArrayMethods = new WeakSet();
-for(const key of Reflect.ownKeys(Float16ArrayPrototype)) {
+for (const key of Reflect.ownKeys(Float16ArrayPrototype)) {
     const val = Float16ArrayPrototype[key];
     if (typeof val === "function") {
         defaultFloat16ArrayMethods.add(val);

--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -5,7 +5,6 @@ import { convertToNumber, roundToFloat16Bits } from "./lib.mjs";
 import { createPrivateStorage } from "./private.mjs";
 import { LengthOfArrayLike, SpeciesConstructor, ToIntegerOrInfinity, defaultCompareFunction } from "./spec.mjs";
 
-
 const _ = createPrivateStorage();
 
 /**
@@ -502,7 +501,10 @@ export default class Float16Array extends Uint16Array {
     set(input, ...opts) {
         assertFloat16Array(this);
 
-        const offset = opts[0];
+        const offset = ToIntegerOrInfinity(opts[0]);
+        if (offset < 0) {
+            throw RangeError("offset is out of bounds");
+        }
 
         let float16bits;
 
@@ -512,12 +514,10 @@ export default class Float16Array extends Uint16Array {
 
         // input others
         } else {
-            const arrayLike = !Reflect.has(input, "length") && input[Symbol.iterator] !== undefined ? [...input] : input;
-            const length = arrayLike.length;
-
+            const length = LengthOfArrayLike(input);
             float16bits = new Uint16Array(length);
-            for(let i = 0, l = arrayLike.length; i < l; ++i) {
-                float16bits[i] = roundToFloat16Bits(arrayLike[i]);
+            for(let i = 0; i < length; ++i) {
+                float16bits[i] = roundToFloat16Bits(input[i]);
             }
         }
 

--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -102,8 +102,8 @@ export default class Float16Array extends Uint16Array {
         if (isFloat16Array(input)) {
             super(_(input).target);
 
-        // TypedArray, Array, ArrayLike, Iterable
-        } else if (isObject(input)) {
+        // object without ArrayBuffer
+        } else if (isObject(input) && !isArrayBuffer(input)) {
             // TypedArray
             if (isTypedArray(input)) {
                 const { buffer, length } = input;
@@ -117,11 +117,7 @@ export default class Float16Array extends Uint16Array {
                     this[i] = roundToFloat16Bits(input[i]);
                 }
 
-            // ArrayBuffer
-            } else if (isArrayBuffer(input)) {
-                super(input, byteOffset, length);
-
-            // Iterable
+            // Iterable (Array)
             } else if (isIterable(input)) {
                 const list = [...input];
                 const length = list.length;
@@ -143,7 +139,7 @@ export default class Float16Array extends Uint16Array {
                 }
             }
 
-        // primitive
+        // primitive, ArrayBuffer
         } else {
             switch(arguments.length) {
                 case 0:

--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -207,19 +207,6 @@ export default class Float16Array extends Uint16Array {
     }
 
     /**
-     * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype-@@iterator
-     * @todo It should be same function of `%TypedArray%#values`
-     */
-    [Symbol.iterator]() {
-        const arrayIterator = super[Symbol.iterator]();
-        return wrapInArrayIterator((function* () {
-            for(const val of arrayIterator) {
-                yield convertToNumber(val);
-            }
-        })());
-    }
-
-    /**
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys
      */
     keys() {
@@ -732,6 +719,15 @@ export default class Float16Array extends Uint16Array {
 }
 
 const Float16ArrayPrototype = Float16Array.prototype;
+
+/**
+ * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype-@@iterator
+ */
+Object.defineProperty(Float16ArrayPrototype, Symbol.iterator, {
+    value: Float16ArrayPrototype.values,
+    writable: true,
+    configurable: true,
+});
 
 const defaultFloat16ArrayMethods = new WeakSet();
 for(const key of Reflect.ownKeys(Float16ArrayPrototype)) {

--- a/src/Float16Array.mjs
+++ b/src/Float16Array.mjs
@@ -11,16 +11,24 @@ const _ = createPrivateStorage();
  * @param {unknown} target
  * @returns {boolean}
  */
-function isFloat16Array(target) {
-    return target instanceof Float16Array;
+function isFloat16ArrayProxy(target) {
+    return target instanceof Float16Array && _(target).target !== undefined;
+}
+
+/**
+ * @param {unknown} target
+ * @returns {boolean}
+ */
+ function isFloat16ArrayBits(target) {
+    return target instanceof Float16Array && _(target).proxy !== undefined;
 }
 
 /**
  * @param {unknown} target
  * @throws {TypeError}
  */
-function assertFloat16Array(target) {
-    if (!isFloat16Array(target)) {
+function assertFloat16ArrayBits(target) {
+    if (!isFloat16ArrayBits(target)) {
         throw new TypeError("This is not a Float16Array");
     }
 }
@@ -52,7 +60,7 @@ function copyToArray(float16bits) {
 const applyHandler = {
     apply(func, thisArg, args) {
         // peel off proxy
-        if (isFloat16Array(thisArg)) {
+        if (isFloat16ArrayProxy(thisArg)) {
             return Reflect.apply(func, _(thisArg).target, args);
         }
 
@@ -99,7 +107,7 @@ export default class Float16Array extends Uint16Array {
      */
     constructor(input, byteOffset, length) {
         // input Float16Array
-        if (isFloat16Array(input)) {
+        if (isFloat16ArrayProxy(input)) {
             super(_(input).target);
 
         // object without ArrayBuffer
@@ -210,7 +218,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys
      */
     keys() {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         return super.keys();
     }
@@ -220,7 +228,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.values
      */
     values() {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const arrayIterator = super.values();
         return wrapInArrayIterator((function* () {
@@ -235,7 +243,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries
      */
     entries() {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const arrayIterator = super.entries();
         return wrapInArrayIterator((function* () {
@@ -249,7 +257,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/proposal-relative-indexing-method/#sec-%typedarray%.prototype.at
      */
     at(index) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const length = this.length;
         const relativeIndex = ToIntegerOrInfinity(index);
@@ -266,7 +274,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.map
      */
     map(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -301,7 +309,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.filter
      */
     filter(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -323,7 +331,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce
      */
     reduce(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const length = this.length;
         if (length === 0 && opts.length === 0) {
@@ -350,7 +358,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright
      */
     reduceRight(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const length = this.length;
         if (length === 0 && opts.length === 0) {
@@ -377,7 +385,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach
      */
     forEach(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -390,7 +398,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.find
      */
     find(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -406,7 +414,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.findindex
      */
     findIndex(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -424,7 +432,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/proposal-array-find-from-last/index.html#sec-%typedarray%.prototype.findlast
      */
     findLast(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -440,7 +448,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/proposal-array-find-from-last/index.html#sec-%typedarray%.prototype.findlastindex
      */
     findLastIndex(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -458,7 +466,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.every
      */
     every(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -475,7 +483,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.some
      */
     some(callback, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const thisArg = opts[0];
 
@@ -492,7 +500,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.set
      */
     set(input, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const offset = ToIntegerOrInfinity(opts[0]);
         if (offset < 0) {
@@ -502,7 +510,7 @@ export default class Float16Array extends Uint16Array {
         let float16bits;
 
         // input Float16Array
-        if (isFloat16Array(input)) {
+        if (isFloat16ArrayProxy(input)) {
             float16bits = _(input).target;
 
         // input others
@@ -521,7 +529,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.reverse
      */
     reverse() {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         super.reverse();
 
@@ -532,7 +540,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.fill
      */
     fill(value, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         super.fill(roundToFloat16Bits(value), ...opts);
 
@@ -543,7 +551,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin
      */
     copyWithin(target, start, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         super.copyWithin(target, start, ...opts);
 
@@ -554,7 +562,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.sort
      */
     sort(...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         let compareFunction = opts[0];
 
@@ -573,7 +581,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice
      */
     slice(...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const Constructor = SpeciesConstructor(this, Float16Array);
 
@@ -629,7 +637,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.subarray
      */
     subarray(...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const uint16 = new Uint16Array(this.buffer, this.byteOffset, this.length);
         const float16bits = uint16.subarray(...opts);
@@ -644,7 +652,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.indexof
      */
     indexOf(element, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const length = this.length;
 
@@ -673,7 +681,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.lastindexof
      */
     lastIndexOf(element, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const length = this.length;
 
@@ -701,7 +709,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.includes
      */
     includes(element, ...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const length = this.length;
 
@@ -737,7 +745,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.join
      */
     join(...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const array = copyToArray(this);
 
@@ -748,7 +756,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring
      */
     toLocaleString(...opts) {
-        assertFloat16Array(this);
+        assertFloat16ArrayBits(this);
 
         const array = copyToArray(this);
 
@@ -759,7 +767,7 @@ export default class Float16Array extends Uint16Array {
      * @see https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
      */
     get [Symbol.toStringTag]() {
-        if (isFloat16Array(this)) {
+        if (isFloat16ArrayBits(this)) {
             return "Float16Array";
         }
     }

--- a/src/is.mjs
+++ b/src/is.mjs
@@ -1,7 +1,9 @@
+import isObject from "lodash-es/isObject.js";
 import { ToIntegerOrInfinity } from "./spec.mjs";
 
 export { default as isObject } from "lodash-es/isObject.js";
 export { default as isArrayBuffer } from "lodash-es/isArrayBuffer.js";
+export { default as isTypedArray } from "lodash-es/isTypedArray.js";
 
 /**
  * @param {unknown} value
@@ -9,6 +11,22 @@ export { default as isArrayBuffer } from "lodash-es/isArrayBuffer.js";
  */
 export function isDataView(value) {
     return ArrayBuffer.isView(value) && Object.prototype.toString.call(value) === "[object DataView]";
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isSharedArrayBuffer(value) {
+    return Object.prototype.toString.call(value) === "[object SharedArrayBuffer]";
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isIterable(value) {
+    return isObject(value) && typeof value[Symbol.iterator] === "function";
 }
 
 /**

--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -8,12 +8,12 @@ const uint32View = new Uint32Array(buffer);
 const baseTable = new Uint32Array(512);
 const shiftTable = new Uint32Array(512);
 
-for(let i = 0; i < 256; ++i) {
+for (let i = 0; i < 256; ++i) {
     const e = i - 127;
 
     // very small number (0, -0)
     if (e < -27) {
-        baseTable[i | 0x000] = 0x0000;
+        baseTable[i] = 0x0000;
         baseTable[i | 0x100] = 0x8000;
         shiftTable[i | 0x000] = 24;
         shiftTable[i | 0x100] = 24;
@@ -67,7 +67,7 @@ const exponentTable = new Uint32Array(64);
 const offsetTable = new Uint32Array(64);
 
 mantissaTable[0] = 0;
-for(let i = 1; i < 1024; ++i) {
+for (let i = 1; i < 1024; ++i) {
     let m = i << 13;    // zero pad mantissa bits
     let e = 0;          // zero exponent
 
@@ -82,23 +82,23 @@ for(let i = 1; i < 1024; ++i) {
 
     mantissaTable[i] = m | e;
 }
-for(let i = 1024; i < 2048; ++i) {
+for (let i = 1024; i < 2048; ++i) {
     mantissaTable[i] = 0x38000000 + ((i - 1024) << 13);
 }
 
 exponentTable[0] = 0;
-for(let i = 1; i < 31; ++i) {
+for (let i = 1; i < 31; ++i) {
     exponentTable[i] = i << 23;
 }
 exponentTable[31] = 0x47800000;
 exponentTable[32] = 0x80000000;
-for(let i = 33; i < 63; ++i) {
+for (let i = 33; i < 63; ++i) {
     exponentTable[i] = 0x80000000 + ((i - 32) << 23);
 }
 exponentTable[63] = 0xc7800000;
 
 offsetTable[0] = 0;
-for(let i = 1; i < 64; ++i) {
+for (let i = 1; i < 64; ++i) {
     if (i === 32) {
         offsetTable[i] = 0;
     } else {

--- a/src/spec.mjs
+++ b/src/spec.mjs
@@ -24,6 +24,31 @@ export function ToIntegerOrInfinity(target) {
 
 /**
  * @param {unknown} target
+ * @returns {number}
+ */
+function ToLength(target) {
+    const length = ToIntegerOrInfinity(target);
+    if (length < 0) {
+        return 0;
+    }
+
+    return length < Number.MAX_SAFE_INTEGER ? length : Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * @param {object} arrayLike
+ * @returns {number}
+ */
+export function LengthOfArrayLike(arrayLike) {
+    if (!isObject(arrayLike)) {
+        throw TypeError("this is not a object");
+    }
+
+    return ToLength(arrayLike.length);
+}
+
+/**
+ * @param {object} target
  * @param {Function} defaultConstructor
  * @returns {Function}
  */

--- a/test/Float16Array.js
+++ b/test/Float16Array.js
@@ -458,17 +458,30 @@ describe("Float16Array", () => {
         });
 
         it("respect @@species", () => {
-            class Foo extends Float16Array {}
-            const foo = new Foo([1]);
-            assert( foo.map((val) => val) instanceof Foo );
-            assert( foo[0] === 1 );
+            let step = 0;
+            class Foo extends Float16Array {
+                constructor(...args) {
+                    super(...args);
+                    if (step === 0) {
+                        assert( args.length === 1 );
+                        deepEqualArray( args[0], [1, 2, 3, 4] );
+                        ++step;
+                    } else {
+                        deepEqualArray( args, [4] );
+                    }
+                }
+            }
+            const foo = new Foo([1, 2, 3, 4]).map((val) => val);
+            assert( foo instanceof Foo );
+            deepEqualArray( foo, [1, 2, 3, 4] );
 
             class Bar extends Float16Array {
                 static get [Symbol.species]() { return Float16Array; }
             }
-            const bar = new Bar([1]);
-            assert( !(bar.map((val) => val) instanceof Bar) );
-            assert( bar[0] === 1 );
+            const bar = new Bar([1, 2, 3, 4]).map((val) => val);
+            assert( !(bar instanceof Bar) );
+            assert( bar instanceof Float16Array );
+            deepEqualArray( bar, [1, 2, 3, 4] );
         });
 
     });
@@ -506,17 +519,31 @@ describe("Float16Array", () => {
         });
 
         it("respect @@species", () => {
-            class Foo extends Float16Array {}
-            const foo = new Foo([1]);
-            assert( foo.filter(() => true) instanceof Foo );
-            assert( foo[0] === 1 );
+            let step = 0;
+            class Foo extends Float16Array {
+                constructor(...args) {
+                    super(...args);
+                    if (step === 0) {
+                        assert( args.length === 1 );
+                        deepEqualArray( args[0], [1, 2, 3, 4] );
+                        ++step;
+                    } else {
+                        assert( args.length === 1 );
+                        deepEqualArray( args[0], [1, 2, 3, 4] );
+                    }
+                }
+            }
+            const foo = new Foo([1, 2, 3, 4]).filter(() => true);
+            assert( foo instanceof Foo );
+            deepEqualArray( foo, [1, 2, 3, 4] );
 
             class Bar extends Float16Array {
                 static get [Symbol.species]() { return Float16Array; }
             }
-            const bar = new Bar([1]);
-            assert( !(bar.filter(() => true) instanceof Bar) );
-            assert( bar[0] === 1 );
+            const bar = new Bar([1, 2, 3, 4]).filter(() => true);
+            assert( !(bar instanceof Bar) );
+            assert( bar instanceof Float16Array );
+            deepEqualArray( bar, [1, 2, 3, 4] );
         });
 
     });
@@ -1013,17 +1040,30 @@ describe("Float16Array", () => {
         });
 
         it("respect @@species", () => {
-            class Foo extends Float16Array {}
-            const foo = new Foo([1]);
-            assert( foo.slice() instanceof Foo );
-            assert( foo[0] === 1 );
+            let step = 0;
+            class Foo extends Float16Array {
+                constructor(...args) {
+                    super(...args);
+                    if (step === 0) {
+                        assert( args.length === 1 );
+                        deepEqualArray( args[0], [1, 2, 3, 4] );
+                        ++step;
+                    } else {
+                        deepEqualArray( args, [2] );
+                    }
+                }
+            }
+            const foo = new Foo([1, 2, 3, 4]).slice(2);
+            assert( foo instanceof Foo );
+            deepEqualArray( foo, [3, 4] );
 
             class Bar extends Float16Array {
                 static get [Symbol.species]() { return Float16Array; }
             }
-            const bar = new Bar([1]);
-            assert( !(bar.slice() instanceof Bar) );
-            assert( bar[0] === 1 );
+            const bar = new Bar([1, 2, 3, 4]).slice(2);
+            assert( !(bar instanceof Bar) );
+            assert( bar instanceof Float16Array );
+            assert( bar, [3, 4] );
         });
 
     });
@@ -1056,17 +1096,33 @@ describe("Float16Array", () => {
         });
 
         it("respect @@species", () => {
-            class Foo extends Float16Array {}
-            const foo = new Foo([1]);
-            assert( foo.subarray() instanceof Foo );
-            assert( foo[0] === 1 );
+            let step = 0;
+            class Foo extends Float16Array {
+                constructor(...args) {
+                    super(...args);
+                    if (step === 0) {
+                        assert( args.length === 1 );
+                        deepEqualArray( args[0], [1, 2, 3, 4] );
+                        ++step;
+                    } else {
+                        assert( args.length === 3 );
+                        assert( args[0] instanceof ArrayBuffer );
+                        assert( args[1] === 4 );
+                        assert( args[2] === 2 );
+                    }
+                }
+            }
+            const foo = new Foo([1, 2, 3, 4]).subarray(2);
+            assert( foo instanceof Foo );
+            deepEqualArray( foo, [3, 4] );
 
             class Bar extends Float16Array {
                 static get [Symbol.species]() { return Float16Array; }
             }
-            const bar = new Bar([1]);
-            assert( !(bar.subarray() instanceof Bar) );
-            assert( bar[0] === 1 );
+            const bar = new Bar([1, 2, 3, 4]).subarray(2);
+            assert( !(bar instanceof Bar) );
+            assert( bar instanceof Float16Array );
+            deepEqualArray( bar, [3, 4] );
         });
 
     });

--- a/test/Float16Array.js
+++ b/test/Float16Array.js
@@ -63,11 +63,24 @@ describe("Float16Array", () => {
         deepEqualArray( float16_2, checkArray );
     });
 
-    it("input ArrayLike", () => {
-        const arrayLike = { "0": 1, "1": 1.1, "2": 1.2, "3": 1.3, length: 4 };
+    it("input TypedArray with CustomArrayBuffer", () => {
+        class FooArrayBuffer extends ArrayBuffer {}
+        const buffer = new FooArrayBuffer(16);
+
+        const float16 = new Float16Array( new Float32Array(buffer) );
+
+        assert( float16.BYTES_PER_ELEMENT === 2 );
+        assert( float16.byteOffset === 0 );
+        assert( float16.byteLength === 8 );
+        assert( float16.length === 4 );
+        assert( float16.buffer instanceof FooArrayBuffer );
+    });
+
+    it("input Iterable", () => {
+        const iterable = [1, 1.1, 1.2, 1.3][Symbol.iterator]();
         const checkArray = [1, 1.099609375, 1.19921875, 1.2998046875];
 
-        const float16 = new Float16Array(arrayLike);
+        const float16 = new Float16Array(iterable);
 
         assert( float16.BYTES_PER_ELEMENT === 2 );
         assert( float16.byteOffset === 0 );
@@ -76,11 +89,11 @@ describe("Float16Array", () => {
         deepEqualArray( float16, checkArray );
     });
 
-    it("input Iterator", () => {
-        const iterator = [1, 1.1, 1.2, 1.3][Symbol.iterator]();
+    it("input ArrayLike", () => {
+        const arrayLike = { "0": 1, "1": 1.1, "2": 1.2, "3": 1.3, length: 4 };
         const checkArray = [1, 1.099609375, 1.19921875, 1.2998046875];
 
-        const float16 = new Float16Array(iterator);
+        const float16 = new Float16Array(arrayLike);
 
         assert( float16.BYTES_PER_ELEMENT === 2 );
         assert( float16.byteOffset === 0 );

--- a/test/Float16Array.js
+++ b/test/Float16Array.js
@@ -6,7 +6,7 @@
 function deepEqualArray(x, y) {
     assert(x.length === y.length);
 
-    for(let i = 0, l = x.length; i < l; ++i) {
+    for (let i = 0, l = x.length; i < l; ++i) {
         assert( x[i] === y[i] );
     }
 }
@@ -14,7 +14,7 @@ function deepEqualArray(x, y) {
 function deepEqualNumberArray(x, y) {
     assert(x.length === y.length);
 
-    for(let i = 0, l = x.length; i < l; ++i) {
+    for (let i = 0, l = x.length; i < l; ++i) {
         assert( Object.is(x[i], y[i]) );
     }
 }
@@ -141,7 +141,7 @@ describe("Float16Array", () => {
         const checkArray = [1, 1.099609375, 1.19921875, 1.2998046875];
 
         const float16 = new Float16Array([1, 1.1, 1.2, 1.3]);
-        for(const val of float16) {
+        for (const val of float16) {
             assert( val === checkArray.shift() );
         }
     });
@@ -187,7 +187,7 @@ describe("Float16Array", () => {
 
         float16.sum = function () {
             let ret = 0;
-            for(let i = 0, l = this.length; i < l; ++i) {
+            for (let i = 0, l = this.length; i < l; ++i) {
                 ret += this[i];
             }
             return ret;

--- a/test/Float16Array.js
+++ b/test/Float16Array.js
@@ -226,21 +226,21 @@ describe("Float16Array", () => {
             deepEqualArray( float16_2, checkArray );
         });
 
-        it("input ArrayLike", () => {
-            const arrayLike = { 0: 1, 1: 1.1, 2: 1.2, 3: 1.3, length: 4 };
+        it("input Iterable", () => {
+            const iterable = [1, 1.1, 1.2, 1.3][Symbol.iterator]();
             const checkArray = [1, 1.099609375, 1.19921875, 1.2998046875];
 
-            const float16 = Float16Array.from(arrayLike);
+            const float16 = Float16Array.from(iterable);
 
             assert( float16 instanceof Float16Array );
             deepEqualArray( float16, checkArray );
         });
 
-        it("input Iterator", () => {
-            const iterator = [1, 1.1, 1.2, 1.3][Symbol.iterator]();
+        it("input ArrayLike", () => {
+            const arrayLike = { 0: 1, 1: 1.1, 2: 1.2, 3: 1.3, length: 4 };
             const checkArray = [1, 1.099609375, 1.19921875, 1.2998046875];
 
-            const float16 = Float16Array.from(iterator);
+            const float16 = Float16Array.from(arrayLike);
 
             assert( float16 instanceof Float16Array );
             deepEqualArray( float16, checkArray );
@@ -876,12 +876,12 @@ describe("Float16Array", () => {
             deepEqualArray( float16, [1, 2, 10, 11, 5] );
         });
 
-        it("set Itetator", () => {
+        it("set Iterable (no effect)", () => {
             const float16 = new Float16Array([1, 2, 3, 4, 5]);
-            const iterator = [10, 11][Symbol.iterator]();
+            const Iterable = [10, 11][Symbol.iterator]();
 
-            assert( float16.set(iterator, 2) === undefined );
-            deepEqualArray( float16, [1, 2, 10, 11, 5] );
+            assert( float16.set(Iterable, 2) === undefined );
+            deepEqualArray( float16, [1, 2, 3, 4, 5] );
         });
 
         it("set myself (Float16Array)", () => {

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -29,12 +29,12 @@ module.exports = {
             // show error log
             if(elements.length !== 0) {
                 const promises = [];
-                for(const value of elements) {
+                for (const value of elements) {
                     promises.push(asyncElementIdText(client, value.ELEMENT));
                 }
 
                 const errors = await Promise.all(promises);
-                for(const error of errors) {
+                for (const error of errors) {
                     console.error(red + error + "\n" + reset);
                 }
             }

--- a/tools/power
+++ b/tools/power
@@ -12,7 +12,7 @@ const exec = util.promisify(require("child_process").exec);
         return path.extname(name) === ".js";
     });
 
-    for(const file of files) {
+    for (const file of files) {
         const base = path.basename(file, ".js");
         exec(`npx espower test/${ base }.js | npx exorcist -r ./ docs/test/${ base }.power.js.map > docs/test/${ base }.power.js`);
     }


### PR DESCRIPTION
* `Float16Array` constructor respects input `TypedArray.[[ViewedArrayBuffer]]`'s `@@species`
* `Float16Array` constructor prioritizes Iterable processing over ArrayLike processing
* `Float16Array#set` does nothing if input is a `Iterable` without `ArrayLike`
* `Float16Array#[@@species]` is the same function as `Float16Array#values`
* `Float16Array#{map, filter, slice, subarray}` is more solid implementation
