### PR TITLE
Added browser field as hint for JS bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     }
   },
   "main": "./lib/index.cjs",
+  "browser": "./browser/float16.js",
   "module": "./src/index.mjs",
   "types": "index.d.ts",
   "files": [


### PR DESCRIPTION
Some JS bundlers prefer to have a specific `browser` key in the `package.json` file, in order to bundle files efficiently (as can be read at https://github.com/defunctzombie/package-browser-field-spec). This PR adds the `browser/float16.js` as main entry point in that field