### PR TITLE
Remove common caught exception

### DIFF
--- a/src/_util/is.mjs
+++ b/src/_util/is.mjs
@@ -61,6 +61,8 @@ export function isNativeBigIntTypedArray(value) {
  */
 function isArrayBuffer(value) {
   try {
+    // ArrayBuffers are never arrays
+    if (Array.isArray(value)) return false;
     ArrayBufferPrototypeGetByteLength(/** @type {any} */ (value));
     return true;
   } catch (e) {

--- a/src/_util/is.mjs
+++ b/src/_util/is.mjs
@@ -62,7 +62,9 @@ export function isNativeBigIntTypedArray(value) {
 function isArrayBuffer(value) {
   try {
     // ArrayBuffers are never arrays
-    if (Array.isArray(value)) return false;
+    if (ArrayIsArray(value)) {
+      return false;
+    }
     ArrayBufferPrototypeGetByteLength(/** @type {any} */ (value));
     return true;
   } catch (e) {


### PR DESCRIPTION
Float16Array construction always throws an exception, which is caught. This makes developing with `Pause on caught exceptions` annoying, because of the spurious caught errors.

The attached change removes a lot of these uncaught errors by immediately identifying any `Array.isArray` values as not being `ArrayBuffers`.