### PR TITLE
Fix algorithm typo for float16 conversion table calculations

### DIFF
--- a/src/_util/converter.mjs
+++ b/src/_util/converter.mjs
@@ -75,7 +75,7 @@ for (let i = 0; i < 256; ++i) {
   const e = i - 127;
 
   // very small number (0, -0)
-  if (e < -27) {
+  if (e < -24) {
     baseTable[i]         = 0x0000;
     baseTable[i | 0x100] = 0x8000;
     shiftTable[i]         = 24;


### PR DESCRIPTION
I was looking at the original paper and noticed this number was different. I could not find any issues that would hint that this number was deliberately changed from `-24` to `-27`, so I assume it must have been a mistake.