### PR TITLE
Update package.json exports.types to use `index.v5.7.d.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ".": {
       "require": "./lib/index.cjs",
       "import": "./src/index.mjs",
-      "types": "./index.d.ts"
+      "types": "./index.v5.7.d.ts"
     },
     "./inspect": {
       "require": "./inspect/node.cjs",


### PR DESCRIPTION
Use `index.v5.7.d.ts` in `exports.types` since this takes precedence over `typesVersions` when TypeScript is using the `exports` field.